### PR TITLE
New option "attribute" for HTML5 compliance

### DIFF
--- a/demo_html5.html
+++ b/demo_html5.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+	<meta charset="utf-8" />
+	<title>SyntaxHighlighter Build Test Page</title>
+	<link rel="stylesheet" media="all" href="jquery.highlight.css" />
+	<style>
+		body {
+			background:none repeat scroll 0 0 #FFFFFF;
+			color:#494949;
+			font-family:Verdana,sans-serif;
+			font-size:62.5%;
+			margin:0;
+			padding:0 1.0em;
+		}
+		p {
+			margin:0.5em 0 0;
+			padding:0 0 0.5em;
+			font-size:1.3em;
+			line-height:1.6em;
+		}
+		div.highlight ul.tabs li {
+			font-size: 14px;
+		}
+  </style>
+	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+	<script src="jquery.highlight.js"></script>
+	<script>
+		$(document).ready(function(){
+			$('pre.code').highlight({source:1, zebra:1, indent:'space', list:'ol',attribute: 'data-language'});
+		});
+	</script>
+</head>
+<body>
+<h1>JQuery syntax Highlight Demo</h1>
+<p>This is a test file to insure that everything is working well.</p>
+<h2>CSS code</h2>
+<pre class="code" data-language="css">
+div.highlight { 
+	background:#FFFFFF;
+	border:1px solid #E0E0E0;
+	font-family:"Courier New",Courier,monospace;
+	overflow: hidden;
+}
+div.highlight pre{
+	width: 100%;
+	overflow: auto;
+	padding:0;
+	margin:0;
+	font-size:13px;
+	clear: both;
+}
+
+/* tabs */
+div.highlight ul.tabs {
+	overflow: hidden;
+	padding: 5px 0 5px 0;
+	margin: 0;
+	list-style: none;
+	border-bottom: 1px solid #E0E0E0;
+	width: 100%;
+}
+div.highlight ul.tabs li {
+	padding: 0;
+	margin: 0 5px;
+	float: left;
+	background: none;
+	border-bottom: 1px dashed #CCC;
+	line-height:1.0em;
+	color: #CCC;
+	cursor: pointer;
+}
+div.highlight ul.tabs li.active {
+	border-bottom: none;
+	cursor: default;
+}
+</pre>
+
+<h2>HTML code</h2>
+<pre class="code" data-language="html">
+<div id="page">
+  <div id="header">
+    <h1><a href="#">Burger Pointer</a></h1>              
+      <ul class="left">
+          <li><a href="#">Menu</a></li>
+          <li><a href="#">Location</a></li>
+          <li><a href="#">About Us</a></li>
+          <li><a href="#">BP Gear</a></li>
+      </ul>
+      <ul class="right">
+          <li><a href="#">Contact Us</a></li>
+          <li><a href="#">Work Here</a></li>
+          <li><a href="#">Customer Loyalty</a></li>
+      </ul>
+  </div>
+  <div id="main">
+      <div id="content">
+          <div class="leftcol">
+              <div class="box"><div class="box-top"><div class="box-bottom">
+                  <h2 class="operation">Hours of Operation</h2>
+                  <div class="image"><img src="images/img01.jpg" alt="" /></div>
+                  <p class="work"><strong>Tue-Thu:</strong> 10:30 - 10:00<br />
+                  <strong>Fri:</strong> 10:30 - 11:00<br />
+                  <strong>Sat:</strong> 10:30 - 11:00<br />
+                  <strong>Sun:</strong> 11:30 - 7:30</p>                            
+              </div></div></div>
+              <div class="box"><div class="box-top"><div class="box-bottom">
+                  <h2 class="specials">Specials</h2>
+                  <p>Suspendisse in nunc sed neque sagittis fermentum. Sed varius augue neque, sed euismod risus. Phasellus vitae massa nunc. Donec et mauris tortor. Duis nunc tortor, cursus sed gravida quis, tincidunt in orci. Morbi tristique consectetur velit quis mattis.</p>                            
+              </div></div></div>
+          </div>
+          <div class="rightcol">
+              <h2>“Where the Burgers are BETTER”</h2>
+              <div class="image"><img src="images/img-home.jpg" alt="" /></div>
+          </div>
+      </div>
+      <div id="sidebar">
+          <h2>Burger Pointer Smash</h2>
+          <div class="image"><img src="images/img02.jpg" alt="" /></div>
+          <p>Suspendisse in nunc sed neque sagittis fermentum. Sed varius augue neque</p>
+          <ul class="nav">
+              <li><h3 class="approach"><a href="#">Burger Pointe: A Different c to Burgers</a></h3></li>
+              <li><h3 class="smashingly"><a href="#">New Burger Pointe Chain Doing Smashingly</a></h3></li>
+              <li><h3 class="stores"><a href="#">Burger Pointe Plans to Open Several Tulsa, OKC Stores</a></h3></li>
+          </ul>
+      </div>
+  </div>
+  <div id="footer">
+      <div class="footer">
+          <div class="top">
+              <div class="left">
+                  <h3>Find Us:</h3>
+                  <ul>
+                      <li><a href="#"><img src="images/youtube.gif" alt="" /></a></li>
+                      <li><a href="#"><img src="images/facebook.gif" alt="" /></a></li>
+                      <li><a href="#"><img src="images/twitter.gif" alt="" /></a></li>
+                  </ul>
+              </div>
+              <div class="right">
+                  <h3><a href="#">Our Clients’ Testimonials</a></h3>    
+              </div>
+          </div>
+      </div>
+  </div>
+</div>
+</pre>
+
+<h2>PHP code</h2>
+<pre class="code" data-language="php">
+$a = array(array('p', 'h'), array('p', 'r'), 'o');
+
+if (in_array(array('p', 'h'), $a)) {
+    echo "'ph' was foundn";
+}
+
+if (in_array(array('f', 'i'), $a)) {
+    echo "'fi' was foundn";
+}
+
+if (in_array('o', $a)) {
+    echo "'o' was foundn";
+}
+
+$array = array(0 => 'blue', 1 => 'red', 2 => 'green', 3 => 'red');
+
+$key = array_search('green', $array); // $key = 2;
+$key = array_search('red', $array);   // $key = 1;
+
+/* comment */
+
+/* foreach example 1: value only */
+
+$a = array(1, 2, 3, 17);
+
+foreach ($a as $v) {
+   echo "Current value of $a: $v.n";
+}
+
+/* foreach example 2: value (with key printed for illustration) */
+
+$a = array(1, 2, 3, 17);
+
+$i = 0; /* for illustrative purposes only */
+
+foreach ($a as $v) {
+    echo "$a[$i] => $v.n";
+    $i++;
+}
+
+/* foreach example 3: key and value */
+
+$a = array(
+    "one" => 1,
+    "two" => 2,
+    "three" => 3,
+    "seventeen" => 17
+);
+
+foreach ($a as $k => $v) {
+    echo "$a[$k] => $v.n";
+}
+
+/* foreach example 4: multi-dimensional arrays */
+$a = array();
+$a[0][0] = "a";
+$a[0][1] = "b";
+$a[1][0] = "y";
+$a[1][1] = "z";
+
+foreach ($a as $v1) {
+    foreach ($v1 as $v2) {
+        echo "$v2n";
+    }
+}
+
+/* foreach example 5: dynamic arrays */
+
+foreach (array(1, 2, 3, 4, 5) as $v) {
+    echo "$vn";
+}
+</pre>
+
+<h2>JS code (default)</h2>
+<pre class="code" data-language="js">
+$(document).ready(function(){
+	//init boxes opacity
+	$('#login').css('opacity', '1');
+	$('#member').css('opacity', '0.52');
+	
+	//change boxes opacity on hover
+	$('#login').hover(function(){
+		$("#login").animate({'opacity': '1'}, 200);
+		$("#member").animate({'opacity': '0.52'}, 200);
+	});
+	$('#member').hover(function(){
+		$("#member").animate({'opacity': '1'}, 200);
+		$("#login").animate({'opacity': '0.52'}, 200);
+	});
+	
+	//request membership expand
+	$('#request_membership').click(function(){
+		$('#member_request > div:first').css('display', 'none');
+		$('#member_request > div:last').css('display', 'block');
+		$("#login").css('display', 'none');
+		return false;
+	});
+	
+	//back
+	$('#back').click(function(){
+		$('#member_request > div:first').css('display', 'block');
+		$('#member_request > div:last').css('display', 'none');
+		$("#login").css('display', 'block');
+		return false;
+	});
+	
+	//input 
+	$('input[type="text"],input[type="password"]').focus(function(){
+		$(this).parent().parent().addClass('focus');
+	});
+  $('input[type="text"],input[type="password"]').blur(function(){
+		$(this).parent().parent().removeClass('focus');
+	});
+	
+	initFontSize(); 
+});
+
+//scaling font size
+function initFontSize() {
+  ratio = $(window).width() / 1200 * 16;
+	ratio = Math.floor(ratio * 100) / 100;	
+	if (ratio < 11) ratio = 11;
+	if (ratio > 14) ratio = 14;	
+	$('body').css('font-size', ratio + 'px');
+}
+
+$(window).resize(function() {
+	initFontSize();
+});
+$(window).trigger('resize'); 	
+</pre>
+<br />
+
+</body>
+</html>

--- a/jquery.highlight.js
+++ b/jquery.highlight.js
@@ -19,7 +19,9 @@
 			//indents: "tabs" or "space"  
 			indent: 'tabs',
 			//ordered or unordered list
-			list: 'ol'
+			list: 'ol',
+			//name of the tag attribute to add a special language highlighting
+			attribute: 'lang'
 		}
 		
 		var params = $.extend({}, defaults, element_params);
@@ -27,7 +29,7 @@
 		return this.each(function(){
 			var code_container = $(this);
 			var code_class = $(code_container).attr('class');
-			var code_lang = $(code_container).attr('lang');
+			var code_lang = $(code_container).attr(params.attribute);
 			var code_lang_class = '';
 			if(code_lang!='') {
 				code_lang_class = ' '+code_lang;


### PR DESCRIPTION
Hello Evgeny,

As I said in my email, here are my modifications (not a big stuff) to avoid validation error on the "lang" attribute on "pre" tags.

Commit message :
To be compliant with HTML5 specifications, which requires that the
`lang` attribute of a `pre` tag follows the
[RFC4646](http://tools.ietf.org/html/rfc4646) (be an ISO language code), I added a
user option `attribute` to define the name of the tag attribute to add
a special language highlighting (such as "html", "css" etc) - for
tests, I made a "demo_html5.html" from the old "demo.html".

Thanks for your plugin, it's very useful and so light-weight (!).

P.
