### PR TITLE
add a 'bower.json' to register the plugin in Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,8 @@
+{
+  "name": "jquery.highlight",
+  "version": "1.2.0",
+  "homepage": "https://github.com/ematsakov/highlight",
+  "description": "syntax highlighting of source code snippets in an html page (jQuery plugin)",
+  "main": "jquery.highlight.js",
+  "license": "MIT"
+}


### PR DESCRIPTION
Hello Evgeny,
As I often use your plugin, I would feel quite glad to be able to install it with my other Bower's components. The only thing to do is to add a `bower.json` manifest file to the plugin (I have built here a model) and to run:

```bash
$ bower register jquery.highlight https://github.com/ematsakov/highlight.git
```

I called it **jquery.highlight** as the name is not in use (for now), but you can of course change anything in the manifest ... It is just a "first draft" with all required fields.

What do you think ?